### PR TITLE
feat: disable slack notification when SLACK_WEBHOOK_URL is empty

### DIFF
--- a/notify/slack.go
+++ b/notify/slack.go
@@ -35,6 +35,10 @@ func NewMessage(text string) *SlackMessage {
 }
 
 func (me SlackNotify) SendMessage(slackRequest *SlackMessage) error {
+	if me.WebHookURL == "" {
+		return nil
+	}
+
 	slackRequest.Username = me.Username
 	slackRequest.Icon = ":robot_face:"
 	slackMsg, err := json.Marshal(slackRequest)


### PR DESCRIPTION
# What?

Disable slack notification when SLACK_WEBHOOK_URL is empty.

# Why?

The logs show what doing. Sometimes is enough.